### PR TITLE
Bugfix: Use font option to set font family

### DIFF
--- a/mdframed.sty
+++ b/mdframed.sty
@@ -822,7 +822,7 @@
    \mdf@styledefinition%
    \mdf@footnoteinput%
    \color{\mdf@fontcolor}%
-   \mdf@font%
+   \fontfamily{\mdf@font}\selectfont%
 }
 \newrobustcmd*\mdf@@ignorelastdescenders{%
    \ifbool{mdf@ignorelastdescenders}%


### PR DESCRIPTION
# Problem
When the option `font` exists (either by setting the option in an `mdframed` environment or by setting it as a document option), the value of this option is printed before every `mdframed` environment. 

# Solution
This commit passes the `font` option to the command `\fontfamily` and applies the font to the environment by calling the command `\selectfont`. 

## Note
Because this code is executed inside a block surrounded by `\begingroup` and `\endgroup`, the font family is only applied to the text inside this block.